### PR TITLE
Fix a bug in findViaPeers and add new test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,17 @@
 # Build
 - `protoc --go_out=plugins=grpc:. *.proto`
 
+# Test
+- `go test`
+
 # Protobuf Setup
 - Install [protoc](https://github.com/google/protobuf/releases) compiler manually or by homebrew `$ brew install protobuf`
 - Install `protoc-gen-go plugin`: `go get -u github.com/golang/protobuf/protoc-gen-go`
 - Build Go bindings from `.proto` file. `protoc --go_out=plugins=grpc:. proto/disgover.proto`
 
-# WARNING
+# Run the nodes in Kubernetes
+
+## WARNING
 __Use a fast DNS__
 ```shell
 nano /etc/resolv.conf
@@ -14,8 +19,6 @@ nameserver 8.8.8.8
 ```
 With a slow DNS it takes 5 min to resolve dev stuff and build docker images, per image
 
-
-# Run the nodes in Kubernetes
 - `eval $(minikube docker-env)`
 - Node 1
     - `cd samples/node1`
@@ -40,7 +43,6 @@ With a slow DNS it takes 5 min to resolve dev stuff and build docker images, per
     - `docker push localhost:5000/disgover-sample-node3:v1`
     - `kubectl run disgover-sample-node3 --image=localhost:5000/disgover-sample-node3:v1 --port=9003 --image-pull-policy=Never`
     - `kubectl describe pod disgover-sample-node3 | grep -e IP -e Port`
-
 
 
 # Dispatch KDHT based node discovery engine

--- a/disgover.go
+++ b/disgover.go
@@ -176,13 +176,11 @@ func (disgover *Disgover) PeerPing(ctx context.Context, contact *Contact) (*Cont
 }
 
 func (disgover *Disgover) PeerFind(ctx context.Context, findRequest *FindRequest) (*Contact, error) {
-	fmt.Println(fmt.Sprintf("Disgover-TRACE: PeerFind(): %s", findRequest.ContactId))
-
 	return disgover.Find(findRequest.ContactId, findRequest.Sender)
 }
 
 func (disgover *Disgover) Find(contactId string, sender *Contact) (*Contact, error) {
-	fmt.Println(fmt.Sprintf("Disgover-TRACE: Find(): %s", contactId))
+	fmt.Println(fmt.Sprintf("Disgover-TRACE: Find(): %s in %s by %s", contactId, disgover.ThisContact.Id, sender.Id))
 
 	if contact, ok := disgover.Nodes[contactId]; ok {
 		return contact, nil
@@ -192,13 +190,15 @@ func (disgover *Disgover) Find(contactId string, sender *Contact) (*Contact, err
 }
 
 func (disgover *Disgover) findViaPeers(nodeID string, sender *Contact) (*Contact, error) {
-	fmt.Println(fmt.Sprintf("Disgover-TRACE: findViaPeers(): %s", nodeID))
-
 	peerIDs := disgover.kdht.NearestPeers([]byte(disgover.ThisContact.Id), len(disgover.Nodes))
 
 	for _, peerID := range peerIDs {
 		peerIDAsString := string(peerID)
 		if peerIDAsString == disgover.ThisContact.Id {
+			continue
+		}
+
+		if peerIDAsString == sender.Id {
 			continue
 		}
 

--- a/disgover_test.go
+++ b/disgover_test.go
@@ -1,0 +1,83 @@
+package disgover
+
+import (
+	"net"
+	"strconv"
+	"testing"
+)
+
+var hostNumber = 0
+
+// Verify that multiple nodes can find each other, and find method returns in
+// reasonable time if non-existent node is being tried.
+func TestMultiNodeDisgover(t *testing.T) {
+	var nodes = setupNodes(3)
+	joinAllNodes(nodes)
+
+	// Verify that all nodes can find each other
+	for _, peer1 := range nodes {
+		for _, peer2 := range nodes {
+			if canFindNode(peer1, peer2) == false {
+				t.FailNow()
+			}
+		}
+	}
+
+	// Verify that disjoint nodes cannot be found and find routine returns in time.
+	var newNodes = setupNodes(3)
+	if canFindNode(nodes[0], newNodes[0]) == true {
+		t.FailNow()
+	}
+}
+
+func joinAllNodes(nodes []Disgover) {
+	for _, peer := range nodes {
+		joinNodes(peer, nodes)
+	}
+}
+
+func joinNodes(node Disgover, peers []Disgover) {
+	for _, peer := range peers {
+		node.addOrUpdate(peer.ThisContact)
+	}
+}
+
+func setupNodes(count int) ([]Disgover) {
+	var nodes []Disgover
+	for i := 0; i < count; i++ {
+		hostNumber++
+		var dsg = NewDisgover(
+			&Contact{
+				Id: "host-" + strconv.Itoa(hostNumber),
+				Endpoint: &Endpoint{
+					Host: "127.0.0.1",
+					Port: getNewPort(),
+				},
+			},
+			nil,
+		)
+		dsg.Run()
+		nodes = append(nodes, *dsg)
+	}
+	return nodes
+}
+
+func canFindNode(node Disgover, nodeToFind Disgover) bool {
+	peer, _ := node.Find(nodeToFind.ThisContact.Id, node.ThisContact)
+	return peer != nil
+}
+
+func getNewPort() (int64) {
+	address, err := net.ResolveTCPAddr("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0
+	}
+
+	listener, err := net.ListenTCP("tcp", address)
+	if err != nil {
+		return 0
+	}
+	defer listener.Close()
+	var port = int64(listener.Addr().(*net.TCPAddr).Port)
+	return port
+}


### PR DESCRIPTION
If a non-existent node is searched then the findViaPeers method goes
into an infinite recursive loop, by calling a peer to find searched
node which calls us back and this goes on forever.

Added test to verify that multiple nodes can find each other, and find
method returns in reasonable time if non-existent node is being tried.